### PR TITLE
Major Refactor: Implement Redux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ cache:
     - node_modules
 script:
   - npm test
+  - npm run build

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
+    "enzyme": "^2.7.0",
     "react-scripts": "0.8.4"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "react": "^15.4.1",
     "react-addons-test-utils": "^15.4.2",
     "react-circular-progressbar": "^0.1.3",
-    "react-dom": "^15.4.1"
+    "react-dom": "^15.4.1",
+    "react-redux": "^5.0.2",
+    "redux": "^3.6.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,8 @@
     <title>Reactodoro</title>
   </head>
   <body>
-    <div class="container" id="root"></div>
+    <div class="container">
+      <div id="root"></div>
+    </div>
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PomoProgressBar from './containers/pomo-progress-bar';
 import ActivityListContainer from './containers/activity-list-container';
 
-class App extends Component {
+export class App extends Component {
   render() {
     return (
       <div className="App row">

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -122,7 +122,7 @@ describe('Components', ()=> {
     const props = {};
     props.list = [1, 2, 3];
 
-    it('Activity has a form and renders list of Activities', () => {
+    it('renders AddActivityForm and renders list of Activities', () => {
       const renderer = TestUtils.createRenderer();
       renderer.render(<ActivityList {...props} />);
       const result = renderer.getRenderOutput();
@@ -134,10 +134,40 @@ describe('Components', ()=> {
       result.props.children[1].props.children.length.should.equal(3);
     });
   });
-  // describe('Acitivity');
-  // describe('Add Activity Form');
-  // describe('Change Time form');
-  // describe('Activity List Container');
+  describe('Acitivity', () => {
+    it('Renders a single li element', () => {
+      const renderer = TestUtils.createRenderer();
+      renderer.render(<Activity />);
+
+      const result = renderer.getRenderOutput();
+      result.type.should.equal('li');
+    });
+  });
+  describe('Add Activity Form', () => {
+    it('renders form and children greater than 0', () => {
+      const renderer = TestUtils.createRenderer();
+      renderer.render(<AddActivityForm />);
+      const result = renderer.getRenderOutput();
+      result.type.should.equal('form');
+      result.props.children.length.should.be.above(0);
+    });
+  });
+  describe('Change Time form', () => {
+    it('renders a form', () => {
+      const renderer = TestUtils.createRenderer();
+      renderer.render(<ChangeTimeForm />);
+      const result = renderer.getRenderOutput();
+      result.type.should.equal('form');
+    });
+  });
+  describe('Activity List Container', () => {
+    it('render Activity List component', () => {
+      const renderer = TestUtils.createRenderer();
+      renderer.render(<ActivityListContainer />);
+      const result = renderer.getRenderOutput();
+      result.type.should.equal(ActivityList);
+    });
+  });
 });
 
 describe('Action Tests', () => {

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -72,22 +72,40 @@ describe('Components', ()=> {
   });
   describe('Start button', () => {
     it('renders button w/ proper text when running', () => {
+      const props = {};
+      props.isRunning = true;
+
       const renderer = TestUtils.createRenderer();
-      renderer.render(<StartPausePomoButton isRunning={true} clickHandler={() => {}} />);
+      renderer.render(<StartPausePomoButton {...props} />);
       const result = renderer.getRenderOutput();
 
       result.type.should.equal('button');
       result.props.children.should.equal('Pause');
     });
     it('renders props text when not running', () => {
+      const props = {};
+      props.isRunning = false;
+
       const renderer = TestUtils.createRenderer();
-      renderer.render(<StartPausePomoButton isRunning={false} clickHandler={() => {}} />);
+      renderer.render(<StartPausePomoButton {...props} />);
       const result = renderer.getRenderOutput();
 
       result.type.should.equal('button');
       result.props.children.should.equal('Start');
     });
-    it('calls handler function on click');
+    it('calls handler function on click', () => {
+      const props = {
+        isRunning: true,
+        pause: () => {},
+        start: () => {}
+      };
+
+      const renderer = TestUtils.createRenderer();
+      renderer.render(<StartPausePomoButton {...props} />);
+      const result = renderer.getRenderOutput();
+
+      result.props.onClick.should.equal(props.pause);
+    });
   });
   describe('Pomo Progress Bar', ()=> {
     it('renders all child components', ()=> {
@@ -100,7 +118,22 @@ describe('Components', ()=> {
       result.props.children.length.should.equal(3);
     });
   });
-  // describe('Acitivty List');
+  describe('Acitivty List', () => {
+    const props = {};
+    props.list = [1, 2, 3];
+
+    it('Activity has a form and renders list of Activities', () => {
+      const renderer = TestUtils.createRenderer();
+      renderer.render(<ActivityList {...props} />);
+      const result = renderer.getRenderOutput();
+
+      result.props.children.length.should.equal(2);
+      result.props.children[0].type.should.equal(AddActivityForm);
+      result.props.children[1].type.should.equal('ul');
+
+      result.props.children[1].props.children.length.should.equal(3);
+    });
+  });
   // describe('Acitivity');
   // describe('Add Activity Form');
   // describe('Change Time form');

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -9,7 +9,7 @@ import ChangeTimeForm from '../components/change-time-form';
 import StartPausePomoButton from '../components/start-pause-pomo-button';
 import Activity from '../components/activity';
 import ActivityList from '../components/activity-list';
-import ActivityListContainer from '../containers/activity-list-container';
+import { ActivityListContainer } from '../containers/activity-list-container';
 import AddActivityForm from '../components/add-activity-form';
 
 

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -20,7 +20,7 @@ import * as actions from '../actions/index';
 
 const should = chai.should();
 
-describe('Shallow smoke tests', () => {
+describe('Smoke tests', () => {
   it('App renders without crashing', () => {
     const wrapper = shallow(<App />);
     expect(wrapper.name()).to.equal('div');
@@ -56,8 +56,7 @@ describe('Shallow smoke tests', () => {
     ReactDOM.render(<AddActivityForm />, form);
   });
 });
-
-describe('Components', ()=> {
+describe('Shallow Components', ()=> {
   describe('Circular progress bar', ()=> {
     it('renders with props', () => {
       const totalSeconds = 120;
@@ -169,24 +168,15 @@ describe('Components', ()=> {
     });
   });
 });
-
-describe('Action Tests', () => {
-
-});
-
-describe('Reducer Tests', () => {
-  it('ADD_ACTIVITY reducer', () => {
+describe('Reducers (by action type)', () => {
+  it('ADD_ACTIVITY', () => {
     store.dispatch(actions.addActivity('test activity'));
     store.getState().activities.length.should.equal(3);
   });
-  it('SELECT_ACTIVITY reducer', () => {
+  it('SELECT_ACTIVITY', () => {
     store.dispatch(actions.selectActivity(1));
     store.getState().selectedActivity.should.equal(1);
   });
-  it('START_POMO');
-  it('RUN_POMO');
-  it('PAUSE_POMO');
-  it('COMPLETE_POMO');
   it('RUN_POMO', () => {
     store.dispatch(actions.runPomo());
     store.getState().isRunning.should.equal(true);
@@ -214,8 +204,16 @@ describe('Reducer Tests', () => {
     getActivityInfo(testActivity);
     currentStateActivity.completedSessions.should.equal(1);
   });
-  it('INCREMENT_SECOND');
-  it('SET_POMO_SECONDS');
+  it('INCREMENT_SECOND', () => {
+    const startingSeconds = store.getState().currentSeconds;
+    store.dispatch(actions.incrementSecond());
+    store.getState().currentSeconds.should.equal(startingSeconds + 1)
+  });
+  it('SET_POMO_SECONDS', () => {
+    const seconds = 100;
+    store.dispatch(actions.setPomoSeconds(seconds));
+    store.getState().totalSeconds.should.equal(seconds);
+  });
   it('GET_ACTIVITY_DETAILS');
   it('GET_ARTICLES');
 });

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import chai from 'chai';
 import TestUtils from 'react-addons-test-utils';
 import App from '../App';
-import PomoProgressBar from '../containers/pomo-progress-bar';
+import { PomoProgressBar } from '../containers/pomo-progress-bar';
 import CircularProgress from '../components/circular-progress';
 import ChangeTimeForm from '../components/change-time-form';
 import StartPausePomoButton from '../components/start-pause-pomo-button';
@@ -16,10 +16,11 @@ import AddActivityForm from '../components/add-activity-form';
 const should = chai.should();
 
 describe('Simple smoke tests', () => {
-  it('App renders without crashing', () => {
-    const div = document.createElement('div');
-    ReactDOM.render(<App />, div);
-  });
+  it('App renders without crashing'
+    // , () => {
+    // const div = document.createElement('div');
+    // ReactDOM.render(<App />, div);}
+  );
   it('Pomo container renders without crashing', () => {
     const pomo = document.createElement('div');
     ReactDOM.render(<PomoProgressBar />, pomo);

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import chai from 'chai';
+import chai, { expect } from 'chai';
 import TestUtils from 'react-addons-test-utils';
 import App from '../App';
-import { shallow } from 'enzyme';
+import { shallow, render } from 'enzyme';
 import { PomoProgressBar } from '../containers/pomo-progress-bar';
 import CircularProgress from '../components/circular-progress';
 import ChangeTimeForm from '../components/change-time-form';
@@ -12,13 +12,18 @@ import Activity from '../components/activity';
 import ActivityList from '../components/activity-list';
 import { ActivityListContainer } from '../containers/activity-list-container';
 import AddActivityForm from '../components/add-activity-form';
+import CircularProgressbar from '../components/circular-progress';
 
+//
+import store from '../store';
+import * as actions from '../actions/index';
 
 const should = chai.should();
 
 describe('Shallow smoke tests', () => {
   it('App renders without crashing', () => {
-    shallow(<App />);
+    const wrapper = shallow(<App />);
+    expect(wrapper.name()).to.equal('div');
   });
   it('Pomo container renders without crashing', () => {
     shallow(<PomoProgressBar />);
@@ -68,4 +73,11 @@ describe('Additional Tests', ()=> {
 
 describe('Action Tests', () => {
 
+});
+
+describe('Reducer Tests', () => {
+  it('ADD_ACTIVITY reducer', () => {
+    store.dispatch(actions.addActivity('test activity'));
+    store.getState().activities.length.should.equal(3);
+  });
 });

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import chai from 'chai';
 import TestUtils from 'react-addons-test-utils';
 import App from '../App';
+import { shallow } from 'enzyme';
 import { PomoProgressBar } from '../containers/pomo-progress-bar';
 import CircularProgress from '../components/circular-progress';
 import ChangeTimeForm from '../components/change-time-form';
@@ -15,19 +16,15 @@ import AddActivityForm from '../components/add-activity-form';
 
 const should = chai.should();
 
-describe('Simple smoke tests', () => {
-  it('App renders without crashing'
-    // , () => {
-    // const div = document.createElement('div');
-    // ReactDOM.render(<App />, div);}
-  );
+describe('Shallow smoke tests', () => {
+  it('App renders without crashing', () => {
+    shallow(<App />);
+  });
   it('Pomo container renders without crashing', () => {
-    const pomo = document.createElement('div');
-    ReactDOM.render(<PomoProgressBar />, pomo);
+    shallow(<PomoProgressBar />);
   });
   it('Circular progress bar component renders without crashing', () => {
-    const circularProgress = document.createElement('div');
-    ReactDOM.render(<CircularProgress percentage={50} />, circularProgress);
+    shallow(<CircularProgress percentage={50} />);
   });
   it('ChangeTimeForm component renders without crashing', () => {
     const form = document.createElement('div');
@@ -47,8 +44,7 @@ describe('Simple smoke tests', () => {
     ReactDOM.render(<ActivityList list={list} />, activityList);
   });
   it('Activity List Container component renders without crashing', () => {
-    const container = document.createElement('div');
-    ReactDOM.render(<ActivityListContainer />, container);
+    shallow(<ActivityListContainer />);
   });
   it('Add activity form component renders without crashing', () => {
     const form = document.createElement('div');
@@ -56,7 +52,7 @@ describe('Simple smoke tests', () => {
   });
 });
 
-describe('Shallow Component Tests', ()=> {
+describe('Additional Tests', ()=> {
   it('Circular progress bar component renders with props', ()=> {
     const totalSeconds = 120;
     const percentage = 50;
@@ -68,4 +64,8 @@ describe('Shallow Component Tests', ()=> {
     result.props.percentage.should.equal(50);
   });
   it('Start button renders with proper text');
+});
+
+describe('Action Tests', () => {
+
 });

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -57,18 +57,54 @@ describe('Shallow smoke tests', () => {
   });
 });
 
-describe('Additional Tests', ()=> {
-  it('Circular progress bar component renders with props', ()=> {
-    const totalSeconds = 120;
-    const percentage = 50;
+describe('Components', ()=> {
+  describe('Circular progress bar', ()=> {
+    it('renders with props', () => {
+      const totalSeconds = 120;
+      const percentage = 50;
 
-    const renderer = TestUtils.createRenderer();
-    renderer.render(<CircularProgress totalSeconds={totalSeconds} percentage={percentage} />);
-    const result = renderer.getRenderOutput();
+      const renderer = TestUtils.createRenderer();
+      renderer.render(<CircularProgress totalSeconds={totalSeconds} percentage={percentage} />);
+      const result = renderer.getRenderOutput();
 
-    result.props.percentage.should.equal(50);
+      result.props.percentage.should.equal(50);
+    });
   });
-  it('Start button renders with proper text');
+  describe('Start button', () => {
+    it('renders button w/ proper text when running', () => {
+      const renderer = TestUtils.createRenderer();
+      renderer.render(<StartPausePomoButton isRunning={true} clickHandler={() => {}} />);
+      const result = renderer.getRenderOutput();
+
+      result.type.should.equal('button');
+      result.props.children.should.equal('Pause');
+    });
+    it('renders props text when not running', () => {
+      const renderer = TestUtils.createRenderer();
+      renderer.render(<StartPausePomoButton isRunning={false} clickHandler={() => {}} />);
+      const result = renderer.getRenderOutput();
+
+      result.type.should.equal('button');
+      result.props.children.should.equal('Start');
+    });
+    it('calls handler function on click');
+  });
+  describe('Pomo Progress Bar', ()=> {
+    it('renders all child components', ()=> {
+      const renderer = TestUtils.createRenderer();
+      renderer.render(<PomoProgressBar />);
+      const result = renderer.getRenderOutput();
+
+      result.type.should.equal('div');
+      result.props.className.should.equal('pomodoro-progress-bar');
+      result.props.children.length.should.equal(3);
+    });
+  });
+  // describe('Acitivty List');
+  // describe('Acitivity');
+  // describe('Add Activity Form');
+  // describe('Change Time form');
+  // describe('Activity List Container');
 });
 
 describe('Action Tests', () => {
@@ -80,4 +116,16 @@ describe('Reducer Tests', () => {
     store.dispatch(actions.addActivity('test activity'));
     store.getState().activities.length.should.equal(3);
   });
+  it('SELECT_ACTIVITY reducer', () => {
+    store.dispatch(actions.selectActivity(1));
+    store.getState().selectedActivity.should.equal(1);
+  });
+  it('START_POMO');
+  it('RUN_POMO');
+  it('PAUSE_POMO');
+  it('COMPLETE_POMO');
+  it('INCREMENT_SECOND');
+  it('SET_POMO_SECONDS');
+  it('GET_ACTIVITY_DETAILS');
+  it('GET_ARTICLES');
 });

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -187,6 +187,33 @@ describe('Reducer Tests', () => {
   it('RUN_POMO');
   it('PAUSE_POMO');
   it('COMPLETE_POMO');
+  it('RUN_POMO', () => {
+    store.dispatch(actions.runPomo());
+    store.getState().isRunning.should.equal(true);
+  });
+  it('PAUSE_POMO', () => {
+    store.dispatch(actions.pausePomo());
+    store.getState().isRunning.should.equal(false);
+  });
+  it('COMPLETE_POMO', () => {
+    const testActivity = 'Coding';
+    let currentStateActivity;
+
+    const getActivityInfo = (activity) => {
+      store.getState().activities.forEach((a) => {
+        if (a.name === testActivity) {
+          currentStateActivity = a;
+        }
+      });
+    };
+
+    getActivityInfo(testActivity);
+    currentStateActivity.completedSessions.should.equal(0);
+
+    store.dispatch(actions.completePomo(testActivity));
+    getActivityInfo(testActivity);
+    currentStateActivity.completedSessions.should.equal(1);
+  });
   it('INCREMENT_SECOND');
   it('SET_POMO_SECONDS');
   it('GET_ACTIVITY_DETAILS');

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,0 +1,54 @@
+
+export const COMPLETE_POMO = 'COMPLETE_POMO';
+export const completePomo = activity => {
+  return {
+    type: COMPLETE_POMO,
+    payload: {
+      activity
+    }
+  };
+};
+
+export const GET_ARTICLES = 'GET_ARTICLES';
+export const getArticles = () => {
+
+}
+
+export const GET_ACTIVITY_DETAILS = 'GET_ACTIVITY_DETAILS';
+export const getActivityDETAILS = () => {
+
+}
+
+export const ADD_ACTIVITY = 'ADD_ACTIVITY';
+export const addActivity = () => {
+
+}
+
+export const REMOVE_ACTIVITY = 'REMOVE_ACTIVITY';
+export const removeActivity = () => {
+
+}
+
+export const SELECT_ACTIVITY = 'SELECT_ACTIVITY';
+export const selectActivity = () => {
+
+}
+
+export const START_POMO = 'START_POMO';
+export const startPomo = () => {
+
+}
+
+export const PAUSE_POMO = 'PAUSE_POMO';
+export const pausePomo = () => {
+
+}
+
+export const SET_POMO_SECONDS = 'SET_POMO_SECONDS';
+export const setPomoSeconds = (totalSeconds) => {
+  return {
+    type: SET_POMO_SECONDS,
+    totalSeconds
+  }
+
+}

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -20,8 +20,11 @@ export const getActivityDETAILS = () => {
 }
 
 export const ADD_ACTIVITY = 'ADD_ACTIVITY';
-export const addActivity = () => {
-
+export const addActivity = (activity) => {
+  return {
+    type: ADD_ACTIVITY,
+    activity
+  }
 }
 
 export const REMOVE_ACTIVITY = 'REMOVE_ACTIVITY';

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -36,12 +36,16 @@ export const selectActivity = () => {
 
 export const START_POMO = 'START_POMO';
 export const startPomo = () => {
-
+  return {
+    type: START_POMO,
+  }
 }
 
 export const PAUSE_POMO = 'PAUSE_POMO';
 export const pausePomo = () => {
-
+  return {
+    type: PAUSE_POMO
+  }
 }
 
 export const SET_POMO_SECONDS = 'SET_POMO_SECONDS';
@@ -50,5 +54,18 @@ export const setPomoSeconds = (totalSeconds) => {
     type: SET_POMO_SECONDS,
     totalSeconds
   }
+}
 
+export const INCREMENT_SECOND = 'INCREMENT_SECOND';
+export const incrementSecond = () => {
+  return {
+    type: INCREMENT_SECOND
+  }
+}
+
+export const RUN_POMO = 'RUN_POMO';
+export const runPomo = () => {
+  return {
+    type: RUN_POMO
+  }
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -3,9 +3,7 @@ export const COMPLETE_POMO = 'COMPLETE_POMO';
 export const completePomo = activity => {
   return {
     type: COMPLETE_POMO,
-    payload: {
-      activity
-    }
+    activity
   };
 };
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -30,8 +30,11 @@ export const removeActivity = () => {
 }
 
 export const SELECT_ACTIVITY = 'SELECT_ACTIVITY';
-export const selectActivity = () => {
-
+export const selectActivity = (index) => {
+  return {
+    type: SELECT_ACTIVITY,
+    index
+  }
 }
 
 export const START_POMO = 'START_POMO';

--- a/src/components/activity-list.js
+++ b/src/components/activity-list.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import Activity from './activity';
 import AddActivityForm from './add-activity-form';
 

--- a/src/components/activity-list.js
+++ b/src/components/activity-list.js
@@ -4,7 +4,7 @@ import AddActivityForm from './add-activity-form';
 
 const ActivityList = (props) => {
   const activityList = props.list.map((activity, index) => {
-    return <Activity isSelected={ index === props.selected ? true : false} name={activity} key={index} id={index} onClick={props.handler} />;
+    return <Activity isSelected={ index === props.selected ? true : false} name={activity.name} key={index} id={index} onClick={props.handler} />;
   });
   return (
     <div>

--- a/src/components/activity-list.js
+++ b/src/components/activity-list.js
@@ -3,9 +3,14 @@ import Activity from './activity';
 import AddActivityForm from './add-activity-form';
 
 const ActivityList = (props) => {
-  const activityList = props.list.map((activity, index) => {
-    return <Activity isSelected={ index === props.selected ? true : false} name={activity.name} key={index} id={index} onClick={props.handler} />;
-  });
+  let activityList;
+  if (props.list) {
+    activityList = props.list.map((activity, index) => {
+      return <Activity isSelected={ index === props.selected ? true : false} name={activity.name} key={index} id={index} onClick={props.handler} />;
+    });
+  }
+
+
   return (
     <div>
       <AddActivityForm handleSubmit={props.handleSubmit} handleTextChange={props.handleTextChange} value={props.addActivityText}/>

--- a/src/components/activity.js
+++ b/src/components/activity.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 
 const Activity = (props) => {
   const className = props.isSelected ? 'selected' : null;

--- a/src/components/add-activity-form.js
+++ b/src/components/add-activity-form.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 
 const AddActivityForm = (props) => {
   return (

--- a/src/components/change-time-form.js
+++ b/src/components/change-time-form.js
@@ -1,6 +1,4 @@
-import React, {
-  PropTypes,
-} from 'react';
+import React from 'react';
 
 export default function ChangeTimeForm(props) {
   return (

--- a/src/components/change-time-form.js
+++ b/src/components/change-time-form.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+
 export default function ChangeTimeForm(props) {
   return (
     <form className="">

--- a/src/components/start-pause-pomo-button.js
+++ b/src/components/start-pause-pomo-button.js
@@ -1,6 +1,4 @@
-import React, {
-  PropTypes,
-} from 'react';
+import React from 'react';
 
 export default function StartPausePomoButton(props) {
   const text = props.isRunning ? 'Pause' : 'Start';

--- a/src/containers/activity-list-container.js
+++ b/src/containers/activity-list-container.js
@@ -21,20 +21,19 @@ export class ActivityListContainer extends React.Component {
   selectActivity(event) {
     const id = parseInt(event.target.id, 10);
     this.props.dispatch(actions.selectActivity(id));
-    // this.setState({
-    //   selected: id
-    // });
   }
 
   handleActivitySubmit(event) {
     event.preventDefault();
     this.props.dispatch(actions.addActivity(this.state.addActivityText));
+    // manage localstate of input through component
     this.setState({
       addActivityText: ''
     });
   }
 
   handleActivityTextChange(event) {
+    // Again, managing state in component here
     this.setState({
       addActivityText: event.target.value
     });

--- a/src/containers/activity-list-container.js
+++ b/src/containers/activity-list-container.js
@@ -9,11 +9,9 @@ export class ActivityListContainer extends React.Component {
   constructor(props) {
     super(props);
 
-    // this.state = {
-    //   activities: ['Testing', 'Reading', 'Drinking Water'],
-    //   selected: 0,
-    //   addActivityText: ''
-    // };
+    this.state = {
+      addActivityText: ''
+    };
 
     this.selectActivity = this.selectActivity.bind(this);
     this.handleActivitySubmit = this.handleActivitySubmit.bind(this);
@@ -30,17 +28,16 @@ export class ActivityListContainer extends React.Component {
 
   handleActivitySubmit(event) {
     event.preventDefault();
-    const newArr = this.state.activities.concat(this.state.addActivityText);
-    // this.setState({
-    //   activities: newArr,
-    //   addActivityText: ''
-    // });
+    this.props.dispatch(actions.addActivity(this.state.addActivityText));
+    this.setState({
+      addActivityText: ''
+    });
   }
 
   handleActivityTextChange(event) {
-    // this.setState({
-    //   addActivityText: event.target.value
-    // });
+    this.setState({
+      addActivityText: event.target.value
+    });
   }
 
   render () {
@@ -51,7 +48,7 @@ export class ActivityListContainer extends React.Component {
         list={this.props.activities}
         handleSubmit={this.handleActivitySubmit}
         handleTextChange={this.handleActivityTextChange}
-        addActivityText={this.props.addActivityText}
+        addActivityText={this.state.addActivityText}
       />
     );
   }
@@ -59,7 +56,6 @@ export class ActivityListContainer extends React.Component {
 
 const mapStateToProps = (state, props) => ({
   selectedActivity: state.selectedActivity,
-  addActivityText: state.addActivityText,
   activities: state.activities
 });
 

--- a/src/containers/activity-list-container.js
+++ b/src/containers/activity-list-container.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
 import ActivityList from '../components/activity-list';
 
 class ActivityListContainer extends React.Component {
@@ -17,8 +17,7 @@ class ActivityListContainer extends React.Component {
   }
 
   selectActivity(event) {
-    console.log('Item selected', event.target.id);
-    const id = parseInt(event.target.id);
+    const id = parseInt(event.target.id, 10);
     this.setState({
       selected: id
     });
@@ -26,7 +25,6 @@ class ActivityListContainer extends React.Component {
 
   handleActivitySubmit(event) {
     event.preventDefault();
-    console.log(`Submit ${this.state.addActivityText}`);
     const newArr = this.state.activities.concat(this.state.addActivityText);
     this.setState({
       activities: newArr,

--- a/src/containers/activity-list-container.js
+++ b/src/containers/activity-list-container.js
@@ -1,15 +1,19 @@
-import React from 'react'
+import React from 'react';
+import {connect} from 'react-redux';
+import * as actions from '../actions/index';
+
+//components
 import ActivityList from '../components/activity-list';
 
-class ActivityListContainer extends React.Component {
+export class ActivityListContainer extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      activities: ['Testing', 'Reading', 'Drinking Water'],
-      selected: 0,
-      addActivityText: ''
-    };
+    // this.state = {
+    //   activities: ['Testing', 'Reading', 'Drinking Water'],
+    //   selected: 0,
+    //   addActivityText: ''
+    // };
 
     this.selectActivity = this.selectActivity.bind(this);
     this.handleActivitySubmit = this.handleActivitySubmit.bind(this);
@@ -18,38 +22,45 @@ class ActivityListContainer extends React.Component {
 
   selectActivity(event) {
     const id = parseInt(event.target.id, 10);
-    this.setState({
-      selected: id
-    });
+    this.props.dispatch(actions.selectActivity(id));
+    // this.setState({
+    //   selected: id
+    // });
   }
 
   handleActivitySubmit(event) {
     event.preventDefault();
     const newArr = this.state.activities.concat(this.state.addActivityText);
-    this.setState({
-      activities: newArr,
-      addActivityText: ''
-    });
+    // this.setState({
+    //   activities: newArr,
+    //   addActivityText: ''
+    // });
   }
 
   handleActivityTextChange(event) {
-    this.setState({
-      addActivityText: event.target.value
-    });
+    // this.setState({
+    //   addActivityText: event.target.value
+    // });
   }
 
   render () {
     return (
       <ActivityList
-        selected={this.state.selected}
+        selected={this.props.selectedActivity}
         handler={this.selectActivity}
-        list={this.state.activities}
+        list={this.props.activities}
         handleSubmit={this.handleActivitySubmit}
         handleTextChange={this.handleActivityTextChange}
-        addActivityText={this.state.addActivityText}
+        addActivityText={this.props.addActivityText}
       />
     );
   }
 }
 
-export default ActivityListContainer;
+const mapStateToProps = (state, props) => ({
+  selectedActivity: state.selectedActivity,
+  addActivityText: state.addActivityText,
+  activities: state.activities
+});
+
+export default connect(mapStateToProps)(ActivityListContainer);

--- a/src/containers/pomo-progress-bar.js
+++ b/src/containers/pomo-progress-bar.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import CircularProgress from '../components/circular-progress';
 import ChangeTimeForm from '../components/change-time-form';
 import StartPausePomoButton from '../components/start-pause-pomo-button';

--- a/src/containers/pomo-progress-bar.js
+++ b/src/containers/pomo-progress-bar.js
@@ -27,9 +27,11 @@ export class PomoProgressBar extends React.Component {
   startPomo() {
 
     // set correct state each time startPomo is called
-    this.setState({
-      isRunning: true
-    });
+    this.props.dispatch(actions.runPomo());
+    // TODO: Remove depricated code below
+    // this.setState({
+    //   isRunning: true
+    // });
 
     // start setInterval for timer and return ID
     // so that it can be cleared at anytime
@@ -41,21 +43,24 @@ export class PomoProgressBar extends React.Component {
       // check if pomo is complete, return if it is
       if (this.props.currentSeconds === this.props.totalSeconds + 1) {
         this.props.dispatch(actions.completePomo('Coding'));
-        this.setState({ complete: true, isRunning: false });
+        // TODO: Delete the line below, depricated
+        // this.setState({ complete: true, isRunning: false });
         clearInterval(intervalId);
         return;
       }
       // set the state for percentage during each loop through
-      this.setState({
-        currentSeconds: (this.state.currentSeconds + 1),
-        percentage: ((this.state.currentSeconds / this.state.totalSeconds) * 100)
-      });
+      this.props.dispatch(actions.incrementSecond());
+      // TODO: Get rid of old code below
+      // this.setState({
+      //   currentSeconds: (this.state.currentSeconds + 1),
+      //   percentage: ((this.state.currentSeconds / this.state.totalSeconds) * 100)
+      // });
     }, 1000);
   }
 
   pausePomo() {
     console.log('Pause function called');
-    this.setState({ isRunning: false });
+    this.props.dispatch(actions.pausePomo());
   }
 
   setPomoMinutes(event) {
@@ -78,7 +83,8 @@ const mapStateToProps = (state, props) => ({
   totalSeconds: state.totalSeconds,
   percentage: state.percentage,
   currentSeconds: state.currentSeconds,
-  activities: state.activities
+  activities: state.activities,
+  isComplete: state.isComplete
 });
 
 export default connect(mapStateToProps)(PomoProgressBar);

--- a/src/containers/pomo-progress-bar.js
+++ b/src/containers/pomo-progress-bar.js
@@ -11,14 +11,6 @@ export class PomoProgressBar extends React.Component {
   constructor(props) {
     super(props);
 
-    // this.state = {
-    //   currentSeconds: 0,
-    //   totalSeconds: null,
-    //   percentage: 0,
-    //   complete: false,
-    //   isRunning: false
-    // }
-
     this.startPomo = this.startPomo.bind(this);
     this.pausePomo = this.pausePomo.bind(this);
     this.setPomoMinutes = this.setPomoMinutes.bind(this);
@@ -28,10 +20,6 @@ export class PomoProgressBar extends React.Component {
 
     // set correct state each time startPomo is called
     this.props.dispatch(actions.runPomo());
-    // TODO: Remove depricated code below
-    // this.setState({
-    //   isRunning: true
-    // });
 
     // start setInterval for timer and return ID
     // so that it can be cleared at anytime
@@ -43,18 +31,11 @@ export class PomoProgressBar extends React.Component {
       // check if pomo is complete, return if it is
       if (this.props.currentSeconds === this.props.totalSeconds + 1) {
         this.props.dispatch(actions.completePomo('Coding'));
-        // TODO: Delete the line below, depricated
-        // this.setState({ complete: true, isRunning: false });
         clearInterval(intervalId);
         return;
       }
       // set the state for percentage during each loop through
       this.props.dispatch(actions.incrementSecond());
-      // TODO: Get rid of old code below
-      // this.setState({
-      //   currentSeconds: (this.state.currentSeconds + 1),
-      //   percentage: ((this.state.currentSeconds / this.state.totalSeconds) * 100)
-      // });
     }, 1000);
   }
 

--- a/src/containers/pomo-progress-bar.js
+++ b/src/containers/pomo-progress-bar.js
@@ -1,19 +1,23 @@
 import React from 'react';
+import {connect} from 'react-redux';
+import * as actions from '../actions/index';
+
+// components
 import CircularProgress from '../components/circular-progress';
 import ChangeTimeForm from '../components/change-time-form';
 import StartPausePomoButton from '../components/start-pause-pomo-button';
 
-class PomoProgressBar extends React.Component {
+export class PomoProgressBar extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      currentSeconds: 0,
-      totalSeconds: null,
-      percentage: 0,
-      complete: false,
-      isRunning: false
-    }
+    // this.state = {
+    //   currentSeconds: 0,
+    //   totalSeconds: null,
+    //   percentage: 0,
+    //   complete: false,
+    //   isRunning: false
+    // }
 
     this.startPomo = this.startPomo.bind(this);
     this.pausePomo = this.pausePomo.bind(this);
@@ -30,12 +34,13 @@ class PomoProgressBar extends React.Component {
     // start setInterval for timer and return ID
     // so that it can be cleared at anytime
     let intervalId = setInterval( () => {
-      if (!this.state.isRunning) {
+      if (!this.props.isRunning) {
         clearInterval(intervalId);
         return;
       }
       // check if pomo is complete, return if it is
-      if (this.state.currentSeconds === this.state.totalSeconds + 1) {
+      if (this.props.currentSeconds === this.props.totalSeconds + 1) {
+        this.props.dispatch(actions.completePomo('Coding'));
         this.setState({ complete: true, isRunning: false });
         clearInterval(intervalId);
         return;
@@ -54,18 +59,26 @@ class PomoProgressBar extends React.Component {
   }
 
   setPomoMinutes(event) {
-    this.setState({ totalSeconds: (event.target.value * 60)});
+    this.props.dispatch(actions.setPomoSeconds(event.target.value * 60));
   }
 
   render () {
     return (
       <div className="pomodoro-progress-bar">
-        <CircularProgress percentage={this.state.percentage} totalSeconds={this.state.totalSeconds}/>
-        <ChangeTimeForm onChange={this.setPomoMinutes} value={this.state.totalSeconds}/>
-        <StartPausePomoButton className="start-pomo-btn" isRunning={this.state.isRunning} pause={this.pausePomo} start={this.startPomo} />
+        <CircularProgress percentage={this.props.percentage} totalSeconds={this.props.totalSeconds}/>
+        <ChangeTimeForm onChange={this.setPomoMinutes} value={this.props.totalSeconds}/>
+        <StartPausePomoButton className="start-pomo-btn" isRunning={this.props.isRunning} pause={this.pausePomo} start={this.startPomo} />
       </div>
     )
   }
 }
 
-export default PomoProgressBar;
+const mapStateToProps = (state, props) => ({
+  isRunning: state.isRunning,
+  totalSeconds: state.totalSeconds,
+  percentage: state.percentage,
+  currentSeconds: state.currentSeconds,
+  activities: state.activities
+});
+
+export default connect(mapStateToProps)(PomoProgressBar);

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {Provider} from 'react-redux';
+
+import store from './store';
+
 import App from './App';
 import './index.css';
 
 ReactDOM.render(
-  <App />,
+  <Provider store={store}>
+    <App />
+  </Provider>,
   document.getElementById('root')
 );

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -33,7 +33,7 @@ export const pomoReducer = (state=initialState, action) => {
       if (index === -1) throw new Error('Somehow can\'t find activity', action.activity);
 
       // build new state
-      const incrementedActivity = Object.assign({}, {name: action.activity}, {completedSessions: state.activities[index].completedSessions++});
+      const incrementedActivity = Object.assign({}, {name: action.activity}, {completedSessions: state.activities[index].completedSessions + 1});
       const before = state.activities.slice(0, index);
       const after = state.activities.slice(index + 1);
       const newActivities = [...before, incrementedActivity, ...after];

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -7,10 +7,16 @@ export const initialState = {
   percentage: 0,
   isComplete: false,
   currentSeconds: 0,
+  selectedActivity: 0,
+  addActivityText: '',
   activities: [
     {
       name: 'Coding',
       completedSessions: 0
+    },
+    {
+      name: 'Writing blog posts',
+      completedSessions: 1
     }
   ]
 };
@@ -21,7 +27,7 @@ export const pomoReducer = (state=initialState, action) => {
       // Look for activity name
       // If exists, increment completedSessions++ and return state
       const index = state.activities.findIndex(activity => {
-        console.log(action.payload.activity);
+        console.log(action.payload.activity, 'complete');
         return activity.name === action.payload.activity;
       });
 
@@ -48,6 +54,9 @@ export const pomoReducer = (state=initialState, action) => {
 
     case actions.PAUSE_POMO:
       return {...state, isRunning: false}
+
+    case actions.SELECT_ACTIVITY:
+      return {...state, selectedActivity: action.index}
   }
   return state;
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,5 @@
 import * as actions from '../actions/index';
-import { combineReducers } from 'redux';
+// import { combineReducers } from 'redux';
 
 export const initialState = {
   isRunning: false,
@@ -60,6 +60,7 @@ export const pomoReducer = (state=initialState, action) => {
     const newActivity = { name: action.activity, completedSessions: 0};
     const addedActivities = state.activities.concat(newActivity);
       return {...state, activities: addedActivities}
-  }
-  return state;
+    default:
+      return state;
+    }
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -9,6 +9,7 @@ export const initialState = {
   currentSeconds: 0,
   selectedActivity: 0,
   activities: [
+    // Mock activities for testing
     {
       name: 'Coding',
       completedSessions: 0
@@ -26,14 +27,13 @@ export const pomoReducer = (state=initialState, action) => {
       // Look for activity name
       // If exists, increment completedSessions++ and return state
       const index = state.activities.findIndex(activity => {
-        console.log(action.payload.activity, 'complete');
-        return activity.name === action.payload.activity;
+        return activity.name === action.activity;
       });
 
-      if (index === -1) throw new Error('Somehow can\'t find activity', action.payload.activity);
+      if (index === -1) throw new Error('Somehow can\'t find activity', action.activity);
 
       // build new state
-      const incrementedActivity = Object.assign({}, {name: action.payload.name}, {completedSessions: state.activities[index].completedSessions++});
+      const incrementedActivity = Object.assign({}, {name: action.activity}, {completedSessions: state.activities[index].completedSessions++});
       const before = state.activities.slice(0, index);
       const after = state.activities.slice(index + 1);
       const newActivities = [...before, incrementedActivity, ...after];
@@ -43,7 +43,6 @@ export const pomoReducer = (state=initialState, action) => {
       return {...state, totalSeconds: parseInt(action.totalSeconds, 10)}
 
     case actions.INCREMENT_SECOND:
-      console.log('state:', state);
       const newSeconds = state.currentSeconds + 1;
       const newPercentage = (state.currentSeconds / state.totalSeconds) * 100;
       return {...state, currentSeconds: newSeconds, percentage: newPercentage}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,7 +8,6 @@ export const initialState = {
   isComplete: false,
   currentSeconds: 0,
   selectedActivity: 0,
-  addActivityText: '',
   activities: [
     {
       name: 'Coding',
@@ -57,6 +56,11 @@ export const pomoReducer = (state=initialState, action) => {
 
     case actions.SELECT_ACTIVITY:
       return {...state, selectedActivity: action.index}
+
+    case actions.ADD_ACTIVITY:
+    const newActivity = { name: action.activity, completedSessions: 0};
+    const addedActivities = state.activities.concat(newActivity);
+      return {...state, activities: addedActivities}
   }
   return state;
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,0 +1,38 @@
+import * as actions from '../actions/index';
+import { combineReducers } from 'redux';
+
+export const initialState = {
+  isRunning: false,
+  totalSeconds: 1500,
+  percentage: 0,
+  activities: [
+    {
+      name: 'Coding',
+      completedSessions: 0
+    }
+  ]
+};
+
+export const pomoReducer = (state=initialState, action) => {
+  switch (action.type) {
+    case actions.COMPLETE_POMO:
+      // Look for activity name
+      // If exists, increment completedSessions++ and return state
+      const index = state.activities.findIndex(activity => {
+        console.log(action.payload.activity);
+        return activity.name === action.payload.activity;
+      });
+
+      if (index === -1) throw new Error('Somehow can\'t find activity', action.payload.activity);
+
+      // build new state
+      const incrementedActivity = Object.assign({}, {name: action.payload.name}, {completedSessions: state.activities[index].completedSessions++});
+      const before = state.activities.slice(0, index);
+      const after = state.activities.slice(index + 1);
+      const newActivities = [...before, incrementedActivity, ...after];
+      return {...state, activities: newActivities};
+    case actions.SET_POMO_SECONDS:
+      return {...state, totalSeconds: parseInt(action.totalSeconds, 10)}
+  }
+  return state;
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,8 @@ export const initialState = {
   isRunning: false,
   totalSeconds: 1500,
   percentage: 0,
+  isComplete: false,
+  currentSeconds: 0,
   activities: [
     {
       name: 'Coding',
@@ -31,8 +33,21 @@ export const pomoReducer = (state=initialState, action) => {
       const after = state.activities.slice(index + 1);
       const newActivities = [...before, incrementedActivity, ...after];
       return {...state, activities: newActivities};
+
     case actions.SET_POMO_SECONDS:
       return {...state, totalSeconds: parseInt(action.totalSeconds, 10)}
+
+    case actions.INCREMENT_SECOND:
+      console.log('state:', state);
+      const newSeconds = state.currentSeconds + 1;
+      const newPercentage = (state.currentSeconds / state.totalSeconds) * 100;
+      return {...state, currentSeconds: newSeconds, percentage: newPercentage}
+
+    case actions.RUN_POMO:
+      return {...state, isRunning: true}
+
+    case actions.PAUSE_POMO:
+      return {...state, isRunning: false}
   }
   return state;
 }

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,4 @@
+import {createStore} from 'redux';
+import * as reducers from './reducers/index';
+
+export default createStore(reducers.pomoReducer);


### PR DESCRIPTION
According to the **Three Principles of Redux** my entire app state should be the [single source of truth](https://github.com/reactjs/redux/blob/master/docs/introduction/ThreePrinciples.md#single-source-of-truth), and therefore everything state-wise should be in the single object tree within the single store.

Because of that I'm embarking on a major refactor of my app logic. Instead of passing down functions in the form of props to children, all to update state.... I will be doing `store.dispatch(action)`'s. This is going to require me to not only add Redux, actions, reducers, etc for all of this logic I already wrote, but also to re-think how my app is structured.

I'll be starting with Actions, and here's my thoughts so far:

### Redux Actions
Action | description
------ | -----------
COMPLETE_POMO | Update store to let know pomo session complete
GET_ARTICLES | Retrieves NYTimes articles using API
GET_ACTIVITY_STATS | Retrieve pomodoro activity stats
ADD_ACTIVITY | Adds an activity to track in the list
REMOVE_ACTIVITY | Remove an activity from the list
SELECT_AVTIVITY | Selects a current activity for the pomo session
START_POMO | Start / resume a pomo timer
PAUSE_POMO | Pause a pomo timer
SET_POMO_SECONDS | Sets pomo total time in seconds

----
### ToDo's
- [x] Fix tests to pass with Redux store